### PR TITLE
Update 1.03.ParameterTypes.md

### DIFF
--- a/DesktopAdvanced1Parameters/1.03.ParameterTypes.md
+++ b/DesktopAdvanced1Parameters/1.03.ParameterTypes.md
@@ -144,7 +144,7 @@ Choice (Multiple) and Choice with Alias (Multiple) are very similar parameters (
 <tr>
 <td style="border: 1px solid darkorange">
 <span style="font-family:serif; font-style:italic; font-size:larger">
-Besides the above, there are some more - specialist - parameter types. Which of the following is NOT a valid attribute type? 
+Besides the above, there are some more - specialist - parameter types. Which of the following is NOT a valid parameter type? 
 <br><br>1. Coordinate System Name
 <br>2. Password
 <br>3. String Encoding


### PR DESCRIPTION
Should this say "NOT a valid parameter type" instead of "NOT a valid attribute type"?
